### PR TITLE
add lens contract to .env and create template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,5 @@
+PK=YOUR_PK
+MUMBAI_RPC_URL=https://rpc-mumbai.matic.today
+PROFILE_ID=PROFILE_ID
+LENS_API=https://api-mumbai.lens.dev/
+LENS_HUB_CONTRACT=0xd7B3481De00995046C7850bCe9a5196B7605c367

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ Full documentation is available at [https://docs.lens.dev/docs/introduction](htt
 
 ## Setup
 
-for the scripts to run you need to create a `.env` file with these variables:
+for the scripts to run you need to create a `.env` (or copy the template `cp .env.template .env`) file with these variables:
 
 ```
 PK=YOUR_PK
 MUMBAI_RPC_URL=https://rpc-mumbai.matic.today
 PROFILE_ID=PROFILE_ID
 LENS_API=https://api-mumbai.lens.dev/
+LENS_HUB_CONTRACT=0xd7B3481De00995046C7850bCe9a5196B7605c367
 ```
 
 note `PROFILE_ID` is optional but required on some endpoints!

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,8 @@ export const MUMBAI_RPC_URL = getParamOrExit('MUMBAI_RPC_URL');
 
 export const LENS_API = getParamOrExit('LENS_API');
 
+export const LENS_HUB_CONTRACT = getParamOrExit('LENS_HUB_CONTRACT');
+
 export const PROFILE_ID = getParam('PROFILE_ID');
 
 export const LENS_FOLLOW_NFT_ABI = [

--- a/src/lens-hub.ts
+++ b/src/lens-hub.ts
@@ -1,11 +1,11 @@
 import { ethers } from 'ethers';
-import { LENS_HUB_ABI } from './config';
+import { LENS_HUB_ABI, LENS_HUB_CONTRACT } from './config';
 import { getSigner } from './ethers.service';
 
 // lens contract info can all be found on the deployed
 // contract address on polygon.
 export const lensHub = new ethers.Contract(
-  '0xd7B3481De00995046C7850bCe9a5196B7605c367',
+  LENS_HUB_CONTRACT,
   LENS_HUB_ABI,
   getSigner()
 );


### PR DESCRIPTION
Can we move the hardcoded lens hub contract to the env file as well? And create a template file in the repo so its easier to run `cp`